### PR TITLE
merge datajoint_plus 0.0.18 to main

### DIFF
--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -6,7 +6,6 @@ The primary use case of datajoint_plus is to enable automatic hashing in DataJoi
 datajoint_plus disables table modification from virtual modules. 
 """
 
-from os import confstr_names, error
 import datajoint as dj
 from datajoint.expression import QueryExpression
 import inspect

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -59,7 +59,9 @@ def generate_hash(rows, add_constant_columns:dict=None):
         assert isinstance(add_constant_columns, dict), f' arg add_constant_columns must be Python dictionary instance.'
         for k, v in add_constant_columns.items():
             df[k] = v
-    df.sort_values(by=df.sort_index(axis=1).columns.tolist()) # permutation invariant
+    # permutation invariant hashing
+    df = df.sort_index(axis=1)
+    df = df.sort_values(by=df.columns.tolist()) 
     encoded = simplejson.dumps(df.to_dict(orient='records')).encode()
     dhash = hashlib.md5()
     dhash.update(encoded)

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -863,9 +863,9 @@ class MasterBase(Base):
 
         :param part_restr: restriction to restrict part tables with.
         :param include_parts (part table or list of part tables): part table(s) to restrict. If None, will restrict all part tables of cls.
-        :param exclude_parts (part table or list of part tables): part table(s) to exclude from restriction
+        :param exclude_parts (part table or list of part tables): part table(s) to exclude from restriction.
         :param filter_out_len_zero (bool): If True, parts with len = 0 after restriction are excluded from list.
-        :params as_cls, reload_dependencies: see cls.parts()
+        :param reload_dependencies (bool): reloads DataJoint graph dependencies.
         """
         assert cls.has_parts(reload_dependencies=reload_dependencies), 'No part tables found. If you are expecting part tables, try with reload_dependencies=True.'
 
@@ -954,7 +954,7 @@ class MasterBase(Base):
 
         :param hash: hash to restrict with
         :param hash_name: name of attribute that contains hash. If hash_name is None, cls.hash_name will be used.
-        :params include_parts, exclude_parts, as_cls, reload_dependencies: see `restrict_parts`
+        :params include_parts, exclude_parts, reload_dependencies: see `restrict_parts`
 
         :returns: list of part tables after restriction
         """  
@@ -974,7 +974,7 @@ class MasterBase(Base):
         Restricts master table to any hashes not found in any of its part tables.
 
         :param hash_name: name of attribute that contains hash. If hash_name is None, cls.hash_name will be used.
-        :params part_restr, include_parts, exclude_parts, as_cls, reload_dependencies: see `restrict_parts`
+        :params part_restr, include_parts, exclude_parts, reload_dependencies: see `restrict_parts`
 
         :returns: cls after restriction
         """

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -774,7 +774,7 @@ class MasterBase(Base):
         return new
 
     @classmethod
-    def union_parts(cls, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=False, as_cls=True, reload_dependencies=False):
+    def union_parts(cls, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=False, reload_dependencies=False):
         """
         Returns union of part table primary keys after optional restriction. Requires all part tables in union to have identical primary keys. 
 
@@ -782,14 +782,14 @@ class MasterBase(Base):
 
         :returns: numpy array object
         """  
-        return np.sum([p.proj() for p in cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, as_cls=as_cls, reload_dependencies=reload_dependencies)])
+        return np.sum([p.proj() for p in cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, reload_dependencies=reload_dependencies)])
 
 #     @classmethod
 #     def keys_not_in_parts(cls, part_restr={}, include_parts=None, exclude_parts=None, master_restr={}, parts_kws={}):
 #         return (cls & master_restr) - cls.union_parts(include_parts=include_parts, exclude_parts=exclude_parts, part_restr=part_restr, parts_kws=parts_kws)
 
     @classmethod
-    def join_parts(cls, part_restr={}, join_method=None, join_with_master=False, include_parts=None, exclude_parts=None, filter_out_len_zero=False, as_cls=True, reload_dependencies=False):
+    def join_parts(cls, part_restr={}, join_method=None, join_with_master=False, include_parts=None, exclude_parts=None, filter_out_len_zero=False, reload_dependencies=False):
         """
         Returns join of part tables after optional restriction. 
 
@@ -804,7 +804,7 @@ class MasterBase(Base):
 
         :returns: numpy array object
         """
-        parts = cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, as_cls=as_cls, reload_dependencies=reload_dependencies)
+        parts = cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, reload_dependencies=reload_dependencies)
         
         if join_with_master:
             parts = [FreeTable(cls.connection, cls.full_table_name)] + parts
@@ -857,7 +857,7 @@ class MasterBase(Base):
         return np.product(renamed_parts)
     
     @classmethod
-    def restrict_parts(cls, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=False, as_cls=True, reload_dependencies=False):
+    def restrict_parts(cls, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=False, reload_dependencies=False):
         """
         Restricts part tables of cls. 
 
@@ -870,7 +870,7 @@ class MasterBase(Base):
         assert cls.has_parts(reload_dependencies=reload_dependencies), 'No part tables found. If you are expecting part tables, try with reload_dependencies=True.'
 
         if include_parts is None:
-            parts = cls.parts(as_cls=as_cls) if as_cls else cls.parts(as_objects=True)
+            parts = cls.parts(as_cls=True)
         
         else:
             parts = cls._format_parts(include_parts)
@@ -883,7 +883,7 @@ class MasterBase(Base):
         return  parts if not filter_out_len_zero else [p for p in parts if len(p)>0]
     
     @classmethod
-    def restrict_one_part(cls, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=True, as_cls=True, reload_dependencies=False):
+    def restrict_one_part(cls, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=True, reload_dependencies=False):
         """
         Calls `restrict_parts` with filter_out_len_zero=True by default. If not exactly one part table is returned, then a ValidationError will be raised.
 
@@ -894,7 +894,7 @@ class MasterBase(Base):
 
         :returns: part table after restriction.
         """
-        parts = cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, as_cls=as_cls, reload_dependencies=reload_dependencies)
+        parts = cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, reload_dependencies=reload_dependencies)
 
         if len(parts) > 1:
             raise ValidationError('part_restr can restrict multiple part tables.')
@@ -908,7 +908,7 @@ class MasterBase(Base):
     r1p = restrict_one_part # alias for restrict_one_part
 
     @classmethod
-    def part_table_names_with_hash(cls, hash, hash_name=None, include_parts=None, exclude_parts=None, filter_out_len_zero=True, as_cls=True, reload_dependencies=False):
+    def part_table_names_with_hash(cls, hash, hash_name=None, include_parts=None, exclude_parts=None, filter_out_len_zero=True, reload_dependencies=False):
         """
         Calls `restrict_parts_with_hash` with filter_out_len_zero=True by default.
 
@@ -916,11 +916,11 @@ class MasterBase(Base):
 
         :returns: list of part table names that contain hash.
         """
-        parts = cls.restrict_parts_with_hash(hash=hash, hash_name=hash_name, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, as_cls=as_cls, reload_dependencies=reload_dependencies)
+        parts = cls.restrict_parts_with_hash(hash=hash, hash_name=hash_name, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, reload_dependencies=reload_dependencies)
         return [format_table_name(r.table_name, part=True) for r in parts]
 
     @classmethod
-    def restrict_one_part_with_hash(cls, hash, hash_name=None, include_parts=None, exclude_parts=None, filter_out_len_zero=True, as_cls=True, reload_dependencies=False):
+    def restrict_one_part_with_hash(cls, hash, hash_name=None, include_parts=None, exclude_parts=None, filter_out_len_zero=True, reload_dependencies=False):
         """
         Calls `restrict_parts_with_hash` with filter_out_len_zero=True by default. If not exactly one part table is returned, then a ValidationError will be raised.
 
@@ -928,7 +928,7 @@ class MasterBase(Base):
 
         :returns: part table after restriction
         """
-        parts = cls.restrict_parts_with_hash(hash=hash, hash_name=hash_name, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, as_cls=as_cls, reload_dependencies=reload_dependencies)
+        parts = cls.restrict_parts_with_hash(hash=hash, hash_name=hash_name, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, reload_dependencies=reload_dependencies)
 
         if len(parts) > 1:
             raise ValidationError('Hash found in multiple part tables.')
@@ -942,7 +942,7 @@ class MasterBase(Base):
     r1pwh = restrict_one_part_with_hash # alias for restrict_one_part_with_hash
 
     @classmethod
-    def restrict_parts_with_hash(cls, hash, hash_name=None, include_parts=None, exclude_parts=None, filter_out_len_zero=False, as_cls=True, reload_dependencies=False):
+    def restrict_parts_with_hash(cls, hash, hash_name=None, include_parts=None, exclude_parts=None, filter_out_len_zero=False, reload_dependencies=False):
         """
         Checks all part tables and returns the part table that is successfully restricted by {'hash_name': hash}. 
 
@@ -964,12 +964,12 @@ class MasterBase(Base):
         if hash_name is None:
             raise ValidationError('Table does not have "hash_name" defined, provide it to restrict with hash.')
         
-        parts = cls.restrict_parts(part_restr={hash_name: hash}, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, as_cls=as_cls, reload_dependencies=reload_dependencies)
+        parts = cls.restrict_parts(part_restr={hash_name: hash}, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, reload_dependencies=reload_dependencies)
 
         return [p for p in parts if hash_name in p.heading.names]
     
     @classmethod
-    def hashes_not_in_parts(cls, hash_name=None, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=False, as_cls=True, reload_dependencies=False):
+    def hashes_not_in_parts(cls, hash_name=None, part_restr={}, include_parts=None, exclude_parts=None, filter_out_len_zero=False, reload_dependencies=False):
         """
         Restricts master table to any hashes not found in any of its part tables.
 
@@ -984,7 +984,7 @@ class MasterBase(Base):
         if hash_name is None:
             raise ValidationError('Table does not have "hash_name" defined, provide it to restrict with hash.')
 
-        return cls - np.sum([(dj.U(cls.hash_name) & p) for p in cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, as_cls=as_cls, reload_dependencies=reload_dependencies)])
+        return cls - np.sum([(dj.U(cls.hash_name) & p) for p in cls.restrict_parts(part_restr=part_restr, include_parts=include_parts, exclude_parts=exclude_parts, filter_out_len_zero=filter_out_len_zero, reload_dependencies=reload_dependencies)])
 
     @classmethod
     def insert(cls, rows, replace=False, skip_duplicates=False, ignore_extra_fields=False, allow_direct_insert=None, reload_dependencies=False, insert_to_parts=None, insert_to_parts_kws={}, skip_hashing=False, constant_attrs={}, overwrite_rows=False):

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -154,8 +154,6 @@ def format_rows_to_df(rows):
     else:
         raise ValidationError('Format of rows not recognized. Try inserting a list of dictionaries, a DataJoint expression or a pandas dataframe.')
 
-    assert "index" not in rows.columns, 'rows cannot contain an attribute named "index".'
-
     return rows
 
 

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -466,7 +466,8 @@ class Base:
         """
         Hashes rows and requires a single hash as output.
         
-        See `hash` for kwargs.
+        Warning: rows must be able to be safely converted into a pandas dataframe.
+        kwargs: args for `hash`
         
         :returns (str): hash
         """
@@ -475,16 +476,18 @@ class Base:
         return hashes[0]
 
     @classmethod
-    def hash(cls, rows, unique=False):
+    def hash(cls, rows, unique=False, **kwargs):
         """
         Hashes rows.
+        Warning: rows must be able to be safely converted into a pandas dataframe.
         
+        kwargs: args for `add_hash_to_rows`
         :param rows: rows containing attributes to be hashed. 
         :unique: If True, only unique hashes will be returned. If False, all hashes returned. 
         
         returns (list): list with hash(es)
-        """
-        return cls.add_hash_to_rows(rows)[cls.hash_name].unique().tolist() if unique else cls.add_hash_to_rows(rows)[cls.hash_name].tolist()
+        """ 
+        return cls.add_hash_to_rows(rows, **kwargs)[cls.hash_name].unique().tolist() if unique else cls.add_hash_to_rows(rows, **kwargs)[cls.hash_name].tolist()
 
     @classmethod
     def restrict_with_hash(cls, hash, hash_name=None):

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -370,7 +370,12 @@ class Base:
         Validation for insertion to DataJoint tables that are subclasses of abstract class Base. 
         """
         # ensure sets are disjoint
-        pairwise_disjoint_set_validation(list(cls._must_be_disjoint.values()), list(cls._must_be_disjoint.keys()), error=NotImplementedError)
+        pairwise_disjoint_set_validation(list(cls._must_be_disjoint.values()), list(cls._must_be_disjoint.keys()), error=AttributeError)
+
+
+        # ensure "index" not in attributes
+        if "index" in cls.heading.names:
+            raise AttributeError(f'Attributes cannot be named "index". There is a bug in this DJ version that does not handle this keyword correctly with respect to MySQL.')
 
         cls._is_insert_validated = True
 

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -26,7 +26,7 @@ import logging
 from .table import FreeTable
 from .user_tables import UserTable
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 
 
 class classproperty:

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -1245,7 +1245,7 @@ class DataJointPlusModule(dj.VirtualModule):
     """
     DataJointPlus extension of DataJoint virtual module with the added ability to instantiate from an existing module.
     """
-    def __init__(self, module_name=None, schema_name=None, module=None, schema_obj_name=None, add_externals=None, add_objects=None, create_schema=False, create_tables=False, connection=None, spawn_missing_classes=True, load_dependencies=True, enable_datajoint_flags=True, warn=True):
+    def __init__(self, module_name=None, schema_name=None, module=None, schema_obj_name=None, add_externals=None, add_objects=None, create_schema=False, create_tables=False, connection=None, spawn_missing_classes=True, load_dependencies=True, enable_dj_flags=True, warn=True):
         """
         Add DataJointPlus methods to all DataJoint user tables in a DataJoint virtual module or to an existing module. 
         
@@ -1308,7 +1308,7 @@ class DataJointPlusModule(dj.VirtualModule):
         if add_externals:
             register_externals(add_externals)
         
-        if enable_datajoint_flags:
+        if enable_dj_flags:
             enable_datajoint_flags()
             
         add_datajoint_plus(self)

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -321,13 +321,15 @@ class Base:
                 if getattr(cls, required) is None:
                     raise NotImplementedError(f'Hashing requires class to implement the property "{required}".')
         
-        # ensure one attribute for "hash_name"
-        if cls.hash_name is not None:
-            if isinstance(cls.hash_name, list) or isinstance(cls.hash_name, tuple):
-                if len(cls.hash_name) > 1:
-                    raise NotImplementedError(f'Only one attribute allowed in "hash_name".')
-                else:
-                    cls.hash_name = cls.hash_name[0]
+        # ensure one attribute
+        for name in ['hash_name']:
+            attr = getattr(cls, name)
+            if attr is not None:
+                if isinstance(attr, list) or isinstance(attr, tuple):
+                    if len(attr) > 1:
+                        raise NotImplementedError(f'Only one attribute allowed in "{name}".')
+                    else:
+                        attr = attr[0]
 
         # ensure "hashed_attrs" wrapped in list or tuple
         if cls.hashed_attrs is not None:

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -58,7 +58,7 @@ def generate_hash(rows, add_constant_columns:dict=None):
         assert isinstance(add_constant_columns, dict), f' arg add_constant_columns must be Python dictionary instance.'
         for k, v in add_constant_columns.items():
             df[k] = v
-    df = df.sort_index(axis=1).sort_values(by=[*df.columns])
+    df.sort_values(by=df.sort_index(axis=1).columns.tolist()) # permutation invariant
     encoded = simplejson.dumps(df.to_dict(orient='records')).encode()
     dhash = hashlib.md5()
     dhash.update(encoded)

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -1202,8 +1202,9 @@ def add_datajoint_plus(module):
     """
     Adds DataJointPlus recursively to DataJoint tables inside the module.
     """
-    try:
-        for name in dir(module):
+    
+    for name in dir(module):
+        try:
             if name in ['key_source', '_master', 'master']:
                 continue
             obj = getattr(module, name)
@@ -1216,9 +1217,9 @@ def add_datajoint_plus(module):
                 obj.__bases__ = tuple(bases)
                 obj.parse_hash_info_from_header()
                 add_datajoint_plus(obj)
-    except:
-        logging.warning(f'Could not add DataJointPlus to: {name}.')
-        traceback.print_exc()
+        except:
+            logging.warning(f'Could not add DataJointPlus to: {name}.')
+            traceback.print_exc()
 
 
 def reassign_master_attribute(module):

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -1264,7 +1264,7 @@ class DataJointPlusModule(dj.VirtualModule):
         :param create_schema (bool): if True, create the schema on the database server
         :param create_tables (bool): if True, module.schema can be used as the decorator for declaring new
         :param connection (dj.Connection): a dj.Connection object to pass into the schema
-        :param enable_datajoint_flags (bool): If true runs enable_datajoint_flags. May be necessary to use adapters. 
+        :param enable_dj_flags (bool): If true runs djp.enable_datajoint_flags. May be necessary to use adapters. 
         :param warn (bool): if False, warnings are disabled. 
         :return: the virtual module or modified module with DataJointPlus added.
         """

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -679,7 +679,7 @@ class MasterBase(Base):
         """
         if cls.hash_name is not None:
             if cls.hash_name not in cls.heading.names:
-                raise ValidationError(f'Attribute "{cls.hash_name}" in property "hash_name" must be present in table heading.')
+                raise ValidationError(f'hash_name "{cls.hash_name}" must be present in table heading.')
 
             # hash_name validation
             if not cls._is_hash_name_validated:

--- a/datajoint/datajoint_plus.py
+++ b/datajoint/datajoint_plus.py
@@ -288,12 +288,18 @@ def _validate_hash_name_type_and_parse_hash_len(hash_name, attributes):
     """
     Validates the attribute type of hash_name and extracts the character length of hash.
 
+    :param hash_name: (str) hash_name to validate.
+    :param attributes: (dict) dj_table.heading.attributes dictionary that hash_name will index into.
+
     :returns: 
-        - assertion error if validation fails
+        - error if validation fails
         - hash character length (int) if validation passes
     """
+    try:
+        hash_type = attributes[hash_name].type
+    except KeyError:
+        raise KeyError(f'hash_name "{hash_name}" not found in attributes.') from None
 
-    hash_type = attributes[hash_name].type
     _, m, e = hash_type.rpartition('varchar')
     assert m == 'varchar', 'hash_name attribute must be of varchar type'
 


### PR DESCRIPTION
# Patch Notes

## NOTE: 0.0.18 is incompatible with previous versions of datajoint_plus because of change in hashing mechanism

- Update to hashing mechanism that makes hash invariant to permutations of insert for both column ordering and row ordering even if rows are hashed together (`hash_group=True`).
    - If row ordering is important, add an `idx` column to your insert and include `idx` in the hashed attributes
    - NOTE: do NOT name an index attribute `index`. See below for more detail.
    - Options to deal with tables inserted with previous version of djp:
        - Delete data from table and re-insert with 0.0.18 to generate new hashes (recommended) 
        - Fix schemas to djp < 0.0.18. (not recommended)
- Introduce Error in insert validation step if an attribute named `index` is detected. This is currently disallowed because of a bug in DataJoint that does not correctly handle compatibility with MySQL.
- update to `cls.hash()` to allow kwargs to be passed to `add_hash_to_rows`
- cleans internal mechanism of formatting insert and add warnings that all inserts must be able to be safely converted to pandas dataframes
- Update internal mechanism of disjoint set validation to allow testing of more than 2 sets
- adds `enable_dj_flags` to `create_djp_module` and is TRUE by default.
    - this will turn allow_python_native_blobs to True and other flags important for using externals and adapters
- update `restrict_with_XXX` functions to take `reload_dependencies` as an argument 
- update `restrict_parts_with_XXX` functions to only return parts as `cls` instead of allowing user to choose to return as `objects`
    - returning tables as `objects` has no obvious benefit over returning as `cls` and is buggy when used in combination with adapters